### PR TITLE
allow `expfile_downstream` file to have different gene names than `expfile_upstream`

### DIFF
--- a/aracne/MI.java
+++ b/aracne/MI.java
@@ -129,7 +129,7 @@ public class MI {
 
 		List<String> templist = Arrays.asList(tfList);
 		HashSet<String> temptf = new HashSet<String>(templist);
-		temptf.retainAll(new HashSet<String>(Arrays.asList(genes)));
+		temptf.retainAll(new HashSet<String>(Arrays.asList(genes1)));
 		tfList = temptf.toArray(new String[0]);
 		Arrays.sort(tfList);
 

--- a/aracne/MI.java
+++ b/aracne/MI.java
@@ -124,7 +124,8 @@ public class MI {
 			) {
 		this.genes = rankData2.keySet().toArray(new String[0]);
 		Arrays.sort(genes);
-		this.setSampleNumber(rankData1.get(genes[0]).length);
+	        String[] genes1 = rankData1.keySet().toArray(new String[0]);
+		this.setSampleNumber(rankData1.get(genes1[0]).length);
 
 		List<String> templist = Arrays.asList(tfList);
 		HashSet<String> temptf = new HashSet<String>(templist);


### PR DESCRIPTION
As I was playing around with ARACNe-AP, I was getting the following error because the gene names in expfile_downstream did not match expfile_upstream:
```
Exception in thread "main" java.lang.NullPointerException
        at aracne.MI.<init>(Unknown Source)
        at aracne.Aracne.runAracne(Unknown Source)
        at aracne.Aracne.main(Unknown Source)
```

Looking at the code, I realized this information was only used [here](https://github.com/califano-lab/ARACNe-AP/blob/30967ea10494fcb42c2bfd00604c94907da5397b/aracne/MI.java#L127) to get the number of samples.

I made a little workaround and it worked! :)

Miquel